### PR TITLE
tracks.jsx: track cards display in two columns

### DIFF
--- a/src/pages/tracks.jsx
+++ b/src/pages/tracks.jsx
@@ -20,15 +20,21 @@ function Tracks() {
     }
 
     return (
-        <div>
-        {
+        <div className="container is-fluid">
+
+            <div className="columns is-multiline">
+            {
             tracks.map(track => (
+                <div className="column is-half">
                         <TrackCard
                         title={track.title}
                         artists={track.artists}
                         id={track.id}
                         />
-        ))}
+                </div>
+            ))}
+            </div>
+            
         </div>
     )
 


### PR DESCRIPTION
Previously, track cards would display in one column all the way down. Modified it so it would display in two columns.